### PR TITLE
Develop

### DIFF
--- a/Code/Runtime/Data/NativeTexture2D.cs
+++ b/Code/Runtime/Data/NativeTexture2D.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using Unity.Collections;
@@ -17,14 +17,14 @@ namespace Beans.Unity.Collections
 
 		private NativeArray<Color32> nativePixels;
 
-		private void InitializeNativeData (Color32[] managedPixels)
+		private void InitializeNativeData (NativeArray<Color32> managedPixels)
 		{
 			if (nativePixels.IsCreated)
 				nativePixels.Dispose ();
 			nativePixels = new NativeArray<Color32> (managedPixels, Allocator.Persistent);
 		}
 
-		public void Update (Color32[] managedPixels, int width, int height)
+		public void Update (NativeArray<Color32> managedPixels, int width, int height)
 		{
 			if (!nativePixels.IsCreated || nativePixels.Length != managedPixels.Length)
 				InitializeNativeData (managedPixels);

--- a/Code/Runtime/Mesh/Deformers/CurveDisplaceDeformer.cs
+++ b/Code/Runtime/Mesh/Deformers/CurveDisplaceDeformer.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using Unity.Jobs;
 using Unity.Burst;
 using Unity.Collections;
@@ -73,8 +73,8 @@ namespace Deform
 			{
 				factor = Factor,
 				offset = Offset,
-				firstKeyTime = Curve.keys[0].time,
-				lastKeyTime = Curve.keys[Curve.length - 1].time,
+				firstKeyTime = Curve[0].time,
+				lastKeyTime = Curve[Curve.length - 1].time,
 				meshToAxis = meshToAxis,
 				axisToMesh = meshToAxis.inverse,
 				curve = nativeCurve,

--- a/Code/Runtime/Mesh/Deformers/TextureDisplaceDeformer.cs
+++ b/Code/Runtime/Mesh/Deformers/TextureDisplaceDeformer.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using Unity.Jobs;
 using Unity.Burst;
 using Unity.Collections;
@@ -85,7 +85,7 @@ namespace Deform
 		[SerializeField, HideInInspector] private Transform axis;
 
 		private JobHandle handle;
-		private Color32[] managedPixels;
+		private NativeArray<Color32> managedPixels;
 		private NativeTexture2D nativeTexture;
 		private bool textureDirty = false;
 
@@ -114,7 +114,7 @@ namespace Deform
 		{
 			if (Texture != null && Texture.isReadable)
 			{
-				managedPixels = texture.GetPixels32 ();
+				managedPixels = texture.GetRawTextureData<Color32>();
 				nativeTexture.Update (managedPixels, texture.width, texture.height);
 			}
 			else if (nativeTexture.IsCreated)


### PR DESCRIPTION
**TextureDisplaceDeformer** gets texture using `GetRawTextureData` instead of `GetPixels32`. Returns a NativeArray of pixel data without allocating managed memory.

**CurveDisplaceDeformer** avoids memory allocation by accessing key directly instead of via `.keys`