### PR TITLE
Lattice improvements

### DIFF
--- a/Code/Editor/CreatorWindow.cs
+++ b/Code/Editor/CreatorWindow.cs
@@ -256,8 +256,6 @@ namespace DeformEditor
 
 				EditorGUIUtility.PingObject (newGameObject);
 
-				var newDeformer = newGameObject.AddComponent (attribute.Type) as Deformer;
-
 				if (autoAdd)
 				{
 					if (selectedGameObjects.Length == 1)
@@ -276,6 +274,8 @@ namespace DeformEditor
 						var rotation = Quaternion.Euler (attribute.XRotation, attribute.YRotation, attribute.ZRotation);
 						newGameObject.transform.SetPositionAndRotation (center, rotation);
 					}
+					
+					var newDeformer = newGameObject.AddComponent (attribute.Type) as Deformer;
 
 					var deformables = GetComponents<Deformable> (selectedGameObjects);
 					var groups = GetComponents<GroupDeformer> (selectedGameObjects);
@@ -307,10 +307,13 @@ namespace DeformEditor
 							repeater.DeformerElement.Component = newDeformer;
 						}
 					}
-
 				}
 				else
+				{
+					newGameObject.AddComponent (attribute.Type);
+
 					Selection.activeGameObject = newGameObject;
+				}
 
 				Undo.CollapseUndoOperations (Undo.GetCurrentGroup ());
 			}

--- a/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
+++ b/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
@@ -8,7 +8,7 @@ using UnityEngine.Rendering;
 
 namespace DeformEditor
 {
-    [CustomEditor(typeof(LatticeDeformer)), CanEditMultipleObjects]
+    [CustomEditor(typeof(LatticeDeformer))]
     public class LatticeDeformerEditor : DeformerEditor
     {
         private Vector3Int newResolution;
@@ -131,6 +131,7 @@ namespace DeformEditor
                             Event e = Event.current;
                             if (e.type == EventType.MouseDown && HandleUtility.nearestControl == controlPointHandleID && e.button == 0)
                             {
+                                Debug.Log(controlPointHandleID);
                                 GUIUtility.hotControl = controlPointHandleID;
                                 GUIUtility.keyboardControl = controlPointHandleID;
                                 e.Use();

--- a/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
+++ b/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
@@ -46,6 +46,8 @@ namespace DeformEditor
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
+            
+            LatticeDeformer latticeDeformer = ((LatticeDeformer) target);
 
             serializedObject.UpdateIfRequiredOrScript();
 
@@ -60,15 +62,24 @@ namespace DeformEditor
             if (GUILayout.Button("Update Lattice"))
             {
                 Undo.RecordObject(target, "Update Lattice");
-                ((LatticeDeformer) target).GenerateControlPoints(newResolution, true);
+                latticeDeformer.GenerateControlPoints(newResolution, true);
                 selectedIndices.Clear();
             }
 
             if (GUILayout.Button("Reset Lattice Points"))
             {
                 Undo.RecordObject(target, "Reset Lattice Points");
-                ((LatticeDeformer) target).GenerateControlPoints(newResolution);
+                latticeDeformer.GenerateControlPoints(newResolution);
                 selectedIndices.Clear();
+            }
+
+            if(latticeDeformer.CanAutoFitBounds)
+            {
+                if (GUILayout.Button("Auto-Fit Bounds"))
+                {
+                    Undo.RecordObject(target, "Auto-Fit Bounds");
+                    latticeDeformer.FitBoundsToParentDeformable();
+                }
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
+++ b/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
@@ -86,7 +86,7 @@ namespace DeformEditor
             using (new Handles.DrawingScope(lattice.transform.localToWorldMatrix))
             {
                 var cachedZTest = Handles.zTest;
-                
+
                 // Change the depth testing to only show handles in front of solid objects (i.e. typical depth testing) 
                 Handles.zTest = CompareFunction.LessEqual;
                 DrawLattice(lattice, DeformHandles.LineMode.Solid);
@@ -124,8 +124,10 @@ namespace DeformEditor
                                 GUIUtility.keyboardControl = controlPointHandleID;
                                 e.Use();
 
-                                bool modifierKeyPressed = (e.modifiers & EventModifiers.Control) != 0 || (e.modifiers & EventModifiers.Shift) != 0;
-                                
+                                bool modifierKeyPressed = (e.modifiers & EventModifiers.Control) != 0
+                                                          || (e.modifiers & EventModifiers.Shift) != 0
+                                                          || (e.modifiers & EventModifiers.Command) != 0;
+
                                 if (modifierKeyPressed && selectedIndices.Contains(controlPointIndex))
                                 {
                                     // Pressed a modifier key so toggle the selection
@@ -186,7 +188,7 @@ namespace DeformEditor
                 }
                 else
                 {
-                    position = controlPoints[selectedIndices.First()];
+                    position = controlPoints[selectedIndices.Last()];
                 }
 
                 position = lattice.Target.TransformPoint(position);

--- a/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
+++ b/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
@@ -224,6 +224,26 @@ namespace DeformEditor
                     }
                 }
             }
+            
+            // If the lattice is visible, override Unity's built-in Select All so that it selects all control points 
+            if (Event.current.type == EventType.ExecuteCommand && Event.current.commandName == "SelectAll")
+            {
+                selectedIndices.Clear();
+                var resolution = lattice.Resolution;
+                for (int z = 0; z < resolution.z; z++)
+                {
+                    for (int y = 0; y < resolution.y; y++)
+                    {
+                        for (int x = 0; x < resolution.x; x++)
+                        {
+                            var controlPointIndex = lattice.GetIndex(x, y, z);
+                            selectedIndices.Add(controlPointIndex);
+                        }
+                    }
+                }
+
+                Event.current.Use();
+            }
 
             EditorApplication.QueuePlayerLoopUpdate();
         }

--- a/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
+++ b/Code/Editor/Mesh/Deformers/LatticeDeformerEditor.cs
@@ -131,7 +131,6 @@ namespace DeformEditor
                             Event e = Event.current;
                             if (e.type == EventType.MouseDown && HandleUtility.nearestControl == controlPointHandleID && e.button == 0)
                             {
-                                Debug.Log(controlPointHandleID);
                                 GUIUtility.hotControl = controlPointHandleID;
                                 GUIUtility.keyboardControl = controlPointHandleID;
                                 e.Use();

--- a/Code/Runtime/Mesh/Deformers/LatticeDeformer.cs
+++ b/Code/Runtime/Mesh/Deformers/LatticeDeformer.cs
@@ -24,6 +24,9 @@ namespace Deform
             set { target = value; }
         }
 
+
+        public bool CanAutoFitBounds => transform.GetComponentInParent<Deformable>() != null;
+
         public float3[] ControlPoints => controlPoints;
 
         public Vector3Int Resolution => resolution;
@@ -35,6 +38,20 @@ namespace Deform
         protected virtual void Reset()
         {
             GenerateControlPoints(resolution);
+
+            // Fit to parent deformable by default
+            FitBoundsToParentDeformable();
+        }
+
+        public void FitBoundsToParentDeformable()
+        {
+            Deformable deformable = transform.GetComponentInParent<Deformable>();
+            if (deformable != null)
+            {
+                var bounds = deformable.GetCurrentMesh().bounds;
+                transform.localPosition = bounds.center;
+                transform.localScale = bounds.size;
+            }
         }
 
         public void GenerateControlPoints(Vector3Int newResolution, bool resampleExistingPoints = false)


### PR DESCRIPTION
* Add Mac support for Command button when selecting control points
* Change pivot behaviour to be consistent with scene view selection (last selected object) not hierarchy selection (first selected object)
* Reorder deformer creation to happen after transform reparent so Reset() is called after the deformer is potentially a child transform of a deformable
* LatticeDeformer tries to set its local position/size from the bounds of a parent Deformable if possible, also available as a button press on the inspector
* SelectAll now selects all control points while the lattice is visible
* Lattice editor doesn't work with multiple lattices so don't say it can